### PR TITLE
remove url.host and url.scheme checks for iOS urls

### DIFF
--- a/ios/ImageRecognizer.mm
+++ b/ios/ImageRecognizer.mm
@@ -24,7 +24,7 @@
         inference = tensorFlowInference;
         
         NSURL *labelsUrl = [NSURL URLWithString:labelsInput];
-        if (labelsUrl && labelsUrl.scheme && labelsUrl.host) {
+        if (labelsUrl) {
             NSData * labelData = [[NSData alloc] initWithContentsOfURL: labelsUrl];
             NSString * labelString = [[NSString alloc] initWithData:labelData encoding:NSUTF8StringEncoding];
             labels = [labelString componentsSeparatedByString:@"\n"];
@@ -50,7 +50,7 @@
     NSData * imageData;
     NSURL *imageUrl = [NSURL URLWithString:image];
     NSString * imageType;
-    if (imageUrl && imageUrl.scheme && imageUrl.host) {
+    if (imageUrl) {
         imageData = [[NSData alloc] initWithContentsOfURL: imageUrl];
         imageType = [[imageUrl absoluteString] hasSuffix:@"png"] ? @"png" : @"jpg";
     } else if ([[NSFileManager defaultManager] fileExistsAtPath:image]) {

--- a/ios/TensorFlowInference.mm
+++ b/ios/TensorFlowInference.mm
@@ -53,7 +53,7 @@ namespace {
     LOG(INFO) << "Graph created.";
     
     NSURL *url = [NSURL URLWithString:modelLocation];
-    if (url && url.scheme && url.host) {
+    if (url) {
         NSData *data = [NSData dataWithContentsOfURL:url];
         
         const void *buf = [data bytes];


### PR DESCRIPTION
This pull request is in relationship to the following issue.
https://github.com/reneweb/react-native-tensorflow/issues/12

I found the root of my problems were caused by in debug the path to the model, labels, or image files were `http://localhost...` while in release mode that changes to `file://....`.  There are several if statements that check for a valid scheme and valid host which fails for the `file://...` location.  I've removed those checks and it has fixed my issues.  There may be a more robust way of handling these variances but I thought I would submit what I've found for now.